### PR TITLE
Prevent bug where first RigidBody event handlers do not fire

### DIFF
--- a/packages/react-three-rapier/src/Physics.tsx
+++ b/packages/react-three-rapier/src/Physics.tsx
@@ -279,7 +279,7 @@ export const Physics: FC<RapierWorldProps> = ({
       const rigidBodyHandle1 = collider1.parent()?.handle;
       const rigidBodyHandle2 = collider2.parent()?.handle;
 
-      if (!collider1 || !collider2 || !rigidBodyHandle1 || !rigidBodyHandle2) {
+      if (!collider1 || !collider2 || !rigidBodyHandle1 == null || !rigidBodyHandle2 == null) {
         return;
       }
 


### PR DESCRIPTION
For some reason, the rapier.js library returns 0 as a handle for the first rigidbody when it's created in this line: https://github.com/pmndrs/react-three-rapier/blob/c9dd1a7b74e8fb7f07aa967f29630a78d3be58a1/packages/react-three-rapier/src/hooks.ts#L56

This can be tested by going to the demo scene Transforms and reloading the scene, and looking at the console. Without this change, the event handler will not fire. Below, I show what it looks like when you log the RigidBody - the first handle is always 0:

<img width="771" alt="Screen Shot 2022-08-22 at 8 54 01 PM" src="https://user-images.githubusercontent.com/4617339/186079689-69b16cff-5fb9-4eb3-9486-8649aa069902.png">

Because the handle value is 0, it fails the check changed here, which means the events on the first rigidbody don't fire. Without this change, the console log in the first RigidBody will not fire. With the change they will fire as expected. 

If you just switch between demos, the events will fire properly, but the first rigidbody created always has a handle of 0.

It looks to me like a issue in rapier.js? Should this be addressed there instead? I've never dealt with a rust project. 