### PR TITLE
fix: crash when used a trimesh collider with non-indexed geometry

### DIFF
--- a/.changeset/witty-ladybugs-behave.md
+++ b/.changeset/witty-ladybugs-behave.md
@@ -1,0 +1,5 @@
+---
+"@react-three/rapier": patch
+---
+
+fix: fix crash for non-indexed trimeshes by applying `mergeVertices` from `BufferGeometryUtils` (@machado2)

--- a/packages/react-three-rapier/src/utils.ts
+++ b/packages/react-three-rapier/src/utils.ts
@@ -9,6 +9,8 @@ import {
   Vector3 as RapierVector3,
 } from "@dimforge/rapier3d-compat";
 
+import { mergeVertices } from 'three/examples/jsm/utils/BufferGeometryUtils'
+
 import {
   BufferGeometry,
   Matrix4,
@@ -301,7 +303,8 @@ export const colliderDescFromGeometry = (
 
     case "trimesh":
       {
-        const g = geometry.clone().scale(scale.x, scale.y, scale.z);
+        const clonedGeometry = geometry.index ? geometry.clone() : mergeVertices(geometry);
+        const g = clonedGeometry.scale(scale.x, scale.y, scale.z);
 
         desc = ColliderDesc.trimesh(
           g.attributes.position.array as Float32Array,


### PR DESCRIPTION
With a non indexed geometry (I got one when I used Subtraction on @react-three/csg ),
if you create a RigidBody colliders="trimesh" it will crash trying to read the indexes.

It's related to this issue: https://github.com/pmndrs/react-three-rapier/issues/64
