### PR TITLE
feat(colliders): added the ability to use sensors on colliders

### DIFF
--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -28,7 +28,7 @@ import { AllShapes } from "./all-shapes/AllShapes";
 import { ApiUsage } from "./api-usage/ApiUsage";
 import { Car } from "./car/Car";
 import { Cluster } from "./cluster/Cluster";
-import { ColliderSensor } from "./collider-sensors/ColliderSensor";
+import { ColliderSensorDemo } from "./collider-sensors/ColliderSensor";
 import { Colliders } from "./colliders/Colliders";
 import { CollisionEventsExample } from "./collision-events/CollisionEventsExample";
 import { ComponentsExample } from "./components/Components";
@@ -103,7 +103,7 @@ const routes: Record<string, ReactNode> = {
   kinematics: <Kinematics />,
   "mesh-collider-test": <MeshColliderTest />,
   colliders: <Colliders />,
-  "collider-sensor": <ColliderSensor />,
+  "collider-sensor": <ColliderSensorDemo />,
   "instanced-meshes": <InstancedMeshes />,
   damping: <Damping />,
   "instanced-meshes-compound": <InstancedMeshesCompound />,

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -28,6 +28,7 @@ import { AllShapes } from "./all-shapes/AllShapes";
 import { ApiUsage } from "./api-usage/ApiUsage";
 import { Car } from "./car/Car";
 import { Cluster } from "./cluster/Cluster";
+import { ColliderSensor } from "./collider-sensors/ColliderSensor";
 import { Colliders } from "./colliders/Colliders";
 import { CollisionEventsExample } from "./collision-events/CollisionEventsExample";
 import { ComponentsExample } from "./components/Components";
@@ -102,6 +103,7 @@ const routes: Record<string, ReactNode> = {
   kinematics: <Kinematics />,
   "mesh-collider-test": <MeshColliderTest />,
   colliders: <Colliders />,
+  "collider-sensor": <ColliderSensor />,
   "instanced-meshes": <InstancedMeshes />,
   damping: <Damping />,
   "instanced-meshes-compound": <InstancedMeshesCompound />,

--- a/demo/src/collider-sensors/ColliderSensor.tsx
+++ b/demo/src/collider-sensors/ColliderSensor.tsx
@@ -1,0 +1,50 @@
+import { Box, Sphere } from "@react-three/drei";
+import { RigidBody } from "@react-three/rapier";
+import { useState } from "react";
+import { Demo } from "../App";
+
+const Ball = () => {
+  return (
+    <RigidBody colliders="ball" restitution={2} position={[0, 20, 0]}>
+      <Sphere castShadow receiveShadow>
+        <meshPhysicalMaterial color="red" />
+      </Sphere>
+    </RigidBody>
+  );
+};
+
+const Sensor = () => {
+  const [color, setColor] = useState("blue");
+
+  const toggleColor = () => {
+    if (color === "blue") {
+      setColor("green");
+    } else {
+      setColor("blue");
+    }
+  };
+
+  return (
+    <RigidBody
+      colliders={"cuboid"}
+      colliderType={"sensor"}
+      type="fixed"
+      restitution={1}
+      onCollisionEnter={e => toggleColor()}
+      onCollisionExit={e => toggleColor()}
+    >
+      <Box args={[10, 5, 10]}>
+        <meshPhysicalMaterial color={color} />
+      </Box>
+    </RigidBody>
+  );
+};
+
+export const ColliderSensor: Demo = () => {
+  return (
+    <group>
+      <Ball />
+      <Sensor />
+    </group>
+  );
+};

--- a/demo/src/collider-sensors/ColliderSensor.tsx
+++ b/demo/src/collider-sensors/ColliderSensor.tsx
@@ -1,50 +1,65 @@
 import { Box, Sphere } from "@react-three/drei";
-import { RigidBody } from "@react-three/rapier";
-import { useState } from "react";
+import { Color } from "@react-three/fiber";
+import { CuboidCollider, CuboidColliderProps, RigidBody, RigidBodyProps } from "@react-three/rapier";
+import { ComponentProps, useState } from "react";
 import { Demo } from "../App";
 
-const Ball = () => {
+const useColorToggle = (color1: Color, color2: Color): [color: Color, toggleColor: () => void] => {
+  const [color, setColor] = useState(color1);
+
+  const toggleColor = () => {
+    if (color === color1) {
+      setColor(color2);
+    } else {
+      setColor(color1);
+    }
+  }
+
+  return [color, toggleColor];
+}
+
+type BallProps = Omit<RigidBodyProps, 'colliders'>
+const Ball = (props: BallProps) => {
+  const [color, toggleColor] = useColorToggle('red', 'yellow');
   return (
-    <RigidBody colliders="ball" restitution={2} position={[0, 20, 0]}>
+    <RigidBody colliders="ball" onCollisionEnter={() => toggleColor()} onCollisionExit={() => toggleColor()} {...props}>
       <Sphere castShadow receiveShadow>
-        <meshPhysicalMaterial color="red" />
+        <meshPhysicalMaterial color={color} />
       </Sphere>
     </RigidBody>
   );
 };
 
-const Sensor = () => {
-  const [color, setColor] = useState("blue");
-
-  const toggleColor = () => {
-    if (color === "blue") {
-      setColor("green");
-    } else {
-      setColor("blue");
-    }
-  };
-
+type RigidBodySensorProps = Omit<ComponentProps<typeof Box>, 'position'> & { position?: RigidBodyProps['position'] };
+const RigidBodySensor = ({ position = [0, 0, 0], ...props}: RigidBodySensorProps) => {
+  const [color, toggleColor] = useColorToggle('blue', 'green');
   return (
     <RigidBody
       colliders={"cuboid"}
       colliderType={"sensor"}
       type="fixed"
-      restitution={1}
       onCollisionEnter={e => toggleColor()}
       onCollisionExit={e => toggleColor()}
+      position={position}
     >
-      <Box args={[10, 5, 10]}>
+      <Box {...props}>
         <meshPhysicalMaterial color={color} />
       </Box>
     </RigidBody>
   );
 };
 
-export const ColliderSensor: Demo = () => {
+type ColliderSensorProps = Pick<CuboidColliderProps, 'args' | 'position'>;
+const ColliderSensor = ({args, ...props}: ColliderSensorProps) => <CuboidCollider {...props} args={[args[0] * 0.5, args[1] * 0.5, args[2] * 0.5]} type="sensor" />
+
+export const ColliderSensorDemo: Demo = () => {
   return (
     <group>
-      <Ball />
-      <Sensor />
+      <Ball position={[-5, 20, -10]} restitution={2} />
+      <RigidBodySensor args={[10, 5, 10]} position={[-5, 0, -10]} />
+
+      <Ball position={[5, 20, -10]} restitution={2} />
+      <ColliderSensor args={[10, 5, 10]} position={[5, 0, -10]} />
     </group>
   );
 };

--- a/packages/react-three-rapier/src/Physics.tsx
+++ b/packages/react-three-rapier/src/Physics.tsx
@@ -274,54 +274,79 @@ export const Physics: FC<RapierWorldProps> = ({
       const collider1 = world.getCollider(handle1);
       const collider2 = world.getCollider(handle2);
 
-      const rigidBodyHandle1 = collider1.parent()?.handle;
-      const rigidBodyHandle2 = collider2.parent()?.handle;
-
-      if (!collider1 || !collider2 || rigidBodyHandle1 === undefined || rigidBodyHandle2 === undefined) {
+      if (!collider1 || !collider2) {
         return;
       }
 
-      const rigidBody1 = world.getRigidBody(rigidBodyHandle1);
-      const rigidBody2 = world.getRigidBody(rigidBodyHandle2);
+      const rigidBodyHandle1 = collider1.parent()?.handle;
+      const rigidBodyHandle2 = collider2.parent()?.handle;
 
-      const rigidBody1Events = rigidBodyEvents.get(rigidBodyHandle1);
-      const rigidBoyd2Events = rigidBodyEvents.get(rigidBodyHandle2);
+      const rigidBody1 = rigidBodyHandle1 ? world.getRigidBody(rigidBodyHandle1) : undefined;
+      const rigidBody2 = rigidBodyHandle2 ? world.getRigidBody(rigidBodyHandle2) : undefined;
+
+      const rigidBody1Events = rigidBodyHandle1 ? rigidBodyEvents.get(rigidBodyHandle1) : undefined;
+      const rigidBoyd2Events = rigidBodyHandle2 ? rigidBodyEvents.get(rigidBodyHandle2) : undefined;
 
       const collider1Events = colliderEvents.get(collider1.handle);
       const collider2Events = colliderEvents.get(collider2.handle);
 
       if (started) {
-        world.contactPair(collider1, collider2, (manifold, flipped) => {
-          /* RigidBody events */
+        const intersections = world.intersectionPair(collider1, collider2);
+        if (intersections) {
           rigidBody1Events?.onCollisionEnter?.({
             target: rigidBody2,
             collider: collider2,
-            manifold,
-            flipped
-          });
+          })
 
           rigidBoyd2Events?.onCollisionEnter?.({
             target: rigidBody1,
             collider: collider1,
-            manifold,
-            flipped,
           });
 
           /* Collider events */
           collider1Events?.onCollisionEnter?.({
             target: rigidBody2,
             collider: collider2,
-            manifold,
-            flipped
           })
 
           collider2Events?.onCollisionEnter?.({
             target: rigidBody1,
             collider: collider1,
-            manifold,
-            flipped
           })
-        });
+        } else {
+          world.contactPair(collider1, collider2, (manifold, flipped) => {
+            /* RigidBody events */
+            rigidBody1Events?.onCollisionEnter?.({
+              target: rigidBody2,
+              collider: collider2,
+              manifold,
+              flipped
+            });
+
+            rigidBoyd2Events?.onCollisionEnter?.({
+              target: rigidBody1,
+              collider: collider1,
+              manifold,
+              flipped,
+            });
+
+            /* Collider events */
+            collider1Events?.onCollisionEnter?.({
+              target: rigidBody2,
+              collider: collider2,
+              manifold,
+              flipped
+            })
+
+            collider2Events?.onCollisionEnter?.({
+              target: rigidBody1,
+              collider: collider1,
+              manifold,
+              flipped
+            })
+          });
+        }
+
       } else {
         rigidBody1Events?.onCollisionExit?.({ target: rigidBody2, collider: collider2 });
         rigidBoyd2Events?.onCollisionExit?.({ target: rigidBody1, collider: collider1 });

--- a/packages/react-three-rapier/src/types.ts
+++ b/packages/react-three-rapier/src/types.ts
@@ -105,6 +105,8 @@ export type RigidBodyShape =
   | "roundConvexHull"
   | "roundConvexMesh";
 
+type ColliderType = 'solid' | 'sensor';
+
 export type Vector3Array = [x: number, y: number, z: number];
 export type Boolean3Array = [x: boolean, y: boolean, z: boolean];
 
@@ -118,6 +120,14 @@ export interface UseColliderOptions<ColliderArgs> {
    * Arguments to pass to the collider
    */
   args?: ColliderArgs;
+
+  /**
+   * The solid collider will generate contact forces to prevent colliders from penetrating
+   * each other, whereas sensor colliders will generate events when another collider starts
+   * or stops touching it
+   * @see https://rapier.rs/docs/user_guides/javascript/colliders#collider-type
+   */
+  type?: ColliderType;
 
   /**
    * The mass of this rigid body.
@@ -192,14 +202,14 @@ export interface UseColliderOptions<ColliderArgs> {
 }
 
 export type CollisionEnterPayload = {
-  target: RapierRigidBody;
+  target: RapierRigidBody | undefined;
   collider: RapierCollider;
-  manifold: TempContactManifold;
-  flipped: boolean;
+  manifold?: TempContactManifold;
+  flipped?: boolean;
 }
 
 export type CollisionExitPayload = {
-  target: RapierRigidBody;
+  target: RapierRigidBody | undefined;
   collider: RapierCollider;
 }
 
@@ -267,6 +277,12 @@ export interface UseRigidBodyOptions {
    * Setting this to false will disable automatic colliders.
    */
   colliders?: RigidBodyAutoCollider | false;
+
+  /**
+   * Automatically sets all colliders within this rigid body to this type
+   * unless specified.
+   */
+  colliderType?: ColliderType;
 
   /**
    * Set the friction of auto-generated colliders.

--- a/packages/react-three-rapier/src/utils.ts
+++ b/packages/react-three-rapier/src/utils.ts
@@ -120,7 +120,9 @@ const applyColliderOptions = (collider: Collider, options: UseColliderOptions<an
 
   if (options.solverGroups !== undefined)
     collider.setSolverGroups(options.solverGroups);
-}
+
+  collider.setSensor(options.type === "sensor");
+};
 
 export const createColliderFromOptions: CreateColliderFromOptions = ({
   options,
@@ -272,7 +274,10 @@ export const createCollidersFromChildren: CreateCollidersFromChildren = ({
         : undefined;
       const collider = world.createCollider(desc, actualRigidBody);
 
-      applyColliderOptions(collider, options)
+      applyColliderOptions(collider, {
+        ...options,
+        type: options.colliderType
+      });
 
       colliders.push(collider);
     }


### PR DESCRIPTION
I've added the ability to use sensor colliders: https://rapier.rs/docs/user_guides/javascript/colliders#collider-type

You can see it in action in the **Collider Sensor** demo.

## Use Case
When a player throws a ball into a bucket, I need to figure out whether they've got it in the bucket or missed the shot.

## Usage

### RigidBody
```
<RigidBody colliders="cuboid" colliderType="sensor" onCollisionEnter={e => console.log('collision enter')} onCollisionExit={e => console.log('collision exit')}> 
  <Box />
</RigidBody>
```

### Collider
```
<SomeCollider type="sensor" onCollisionEnter={e => console.log('collision enter')} onCollisionExit={e => console.log('collision exit')}> 
  <Box />
</SomeCollider>
```

## PR Side effects

The collisition event signatures have changes - `target` (rigid body) may now be undefined in the case of colliders (these currently don't work standalone). `manifold` and `flipped` aren't passed through as part of the intersection version of the events.