### PR TITLE
fix: relax three peer dependency

### DIFF
--- a/packages/react-three-rapier/package.json
+++ b/packages/react-three-rapier/package.json
@@ -21,7 +21,7 @@
   "peerDependencies": {
     "@react-three/fiber": "^8.0.12",
     "react": "^18.0.0",
-    "three": "^0.139.2",
+    "three": ">=0.139.2",
     "three-stdlib": "^2.15.0"
   },
   "dependencies": {


### PR DESCRIPTION
This changes the peer dependency to `three` from a `^0.139.2` to a `>=0.139.2`, silencing the missing peer dependency warnings in projects that are using newer versions.

PS. I think `three-stdlib` should be a normal dependency (as opposed to a peer dependency.) Outside of demos, it is only needed for `RoundedBoxGeometry` in `Debug.tsx`, and tree shaking would do its usual thing here.