### PR TITLE
Add vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }],
+  "github": {
+    "silent": true
+  }
+}


### PR DESCRIPTION
This adds a vercel configuration file that does two things, in order of importance:

- rewrite all paths to the demo app (not just `/`)
- silence GitHub notifications for new deployes (remove if you actually want them)

I'm not familiar with your Vercel configuration, so it's possible that you need to move this file somewhere else, but by default Vercel looks for it at the root of the deployed repository.