### PR TITLE
Clean up and fix main loop

### DIFF
--- a/packages/react-three-rapier/src/Physics.tsx
+++ b/packages/react-three-rapier/src/Physics.tsx
@@ -197,7 +197,7 @@ export const Physics: FC<RapierWorldProps> = ({
     }> = {}
 
     // Increase accumulator
-    steppingState.accumulator += paused ? 0 : clamp(dt, 0, 1)
+    steppingState.accumulator += paused ? 0 : clamp(dt, 0, 0.2)
 
     if (!paused) {
       let subSteps = 0

--- a/packages/react-three-rapier/src/Physics.tsx
+++ b/packages/react-three-rapier/src/Physics.tsx
@@ -181,7 +181,7 @@ export const Physics: FC<RapierWorldProps> = ({
     accumulator: 0
   })
 
-  useFrame((_, delta) => {
+  useFrame((_, dt) => {
     const world = worldRef.current;
     if (!world) return;
 
@@ -197,14 +197,13 @@ export const Physics: FC<RapierWorldProps> = ({
     }> = {}
 
     // don't step time forwards if paused
-    const deltaMs = paused ? 0 : clamp(delta, 0, 1) * 1000;
-    const timeStepMs = timeStep * 1000
+    const deltaMs = paused ? 0 : clamp(dt, 0, 1);
 
     steppingState.accumulator += deltaMs
 
     if (!paused) {
       let subSteps = 0
-      while (steppingState.accumulator >= timeStepMs && subSteps < maxSubSteps) {
+      while (steppingState.accumulator >= timeStep && subSteps < maxSubSteps) {
         // Collect previous state
         world.bodies.forEach(b => {
           previousTranslations[b.handle] = {
@@ -215,11 +214,11 @@ export const Physics: FC<RapierWorldProps> = ({
 
         world.step(eventQueue)
         subSteps++
-        steppingState.accumulator -= timeStepMs
+        steppingState.accumulator -= timeStep
       }
     }
 
-    const interpolationAlpha = (steppingState.accumulator % timeStepMs) / timeStepMs
+    const interpolationAlpha = (steppingState.accumulator % timeStep) / timeStep
 
     // Update meshes
     rigidBodyStates.forEach((state, handle) => {

--- a/packages/react-three-rapier/src/Physics.tsx
+++ b/packages/react-three-rapier/src/Physics.tsx
@@ -178,7 +178,6 @@ export const Physics: FC<RapierWorldProps> = ({
   }, [gravity]);
 
   const [steppingState] = useState({
-    time: 0,
     accumulator: 0
   })
 
@@ -201,8 +200,7 @@ export const Physics: FC<RapierWorldProps> = ({
     const deltaMs = paused ? 0 : clamp(delta, 0, 1) * 1000;
     const timeStepMs = timeStep * 1000
 
-    steppingState.time += deltaMs
-    steppingState.accumulator += timeStepMs
+    steppingState.accumulator += deltaMs
 
     if (!paused) {
       let subSteps = 0

--- a/packages/react-three-rapier/src/Physics.tsx
+++ b/packages/react-three-rapier/src/Physics.tsx
@@ -196,10 +196,8 @@ export const Physics: FC<RapierWorldProps> = ({
       translation: Vector3
     }> = {}
 
-    // don't step time forwards if paused
-    const deltaMs = paused ? 0 : clamp(dt, 0, 1);
-
-    steppingState.accumulator += deltaMs
+    // Increase accumulator
+    steppingState.accumulator += paused ? 0 : clamp(dt, 0, 1)
 
     if (!paused) {
       let subSteps = 0

--- a/packages/react-three-rapier/src/Physics.tsx
+++ b/packages/react-three-rapier/src/Physics.tsx
@@ -199,11 +199,11 @@ export const Physics: FC<RapierWorldProps> = ({
     }> = {}
 
     // don't step time forwards if paused
-    const nowTime = steppingState.time += paused ? 0 : clamp(delta, 0, 1) * 1000;
+    const deltaMs = paused ? 0 : clamp(delta, 0, 1) * 1000;
     const timeStepMs = timeStep * 1000
-    const timeSinceLast = nowTime - steppingState.lastTime
-    steppingState.lastTime = nowTime
-    steppingState.accumulator += timeSinceLast
+
+    steppingState.time += deltaMs
+    steppingState.accumulator += timeStepMs
 
     if (!paused) {
       let subSteps = 0

--- a/packages/react-three-rapier/src/Physics.tsx
+++ b/packages/react-three-rapier/src/Physics.tsx
@@ -179,7 +179,6 @@ export const Physics: FC<RapierWorldProps> = ({
 
   const [steppingState] = useState({
     time: 0,
-    lastTime: 0,
     accumulator: 0
   })
 


### PR DESCRIPTION
Even after the previous time clamping update, the main loop was still exhibting the unwanted behavior where simulation speed was highly increased after returning to a backgrounded tab after a few seconds/minutes.

I believe this was because the main loop was still adding too much time to its internal accumulator. This PR simplifies the main loop implementation, and I _think_ I didn't break anything (but please let me know if I did.) 

It does fix the original issue, at least. :P

#### Notes:

- Decreases the clamping cap to 200ms (5 FPS)
- Removes `lastTime` because I am not seeing it used anywhere outside of the old accumulation logic.
- Also removes `time` because it's not used anywhere.
- Removed the unnecessary (I think) multiplications * 1000