### PR TITLE
Import mergeVertices from three-stdlib, fix next.js support

### DIFF
--- a/packages/react-three-rapier/src/utils.ts
+++ b/packages/react-three-rapier/src/utils.ts
@@ -9,7 +9,7 @@ import {
   Vector3 as RapierVector3
 } from "@dimforge/rapier3d-compat";
 
-import { mergeVertices } from "three/examples/jsm/utils/BufferGeometryUtils";
+import { mergeVertices } from "three-stdlib";
 
 import {
   BufferGeometry,


### PR DESCRIPTION
This is my first PR ever so please bear with me.

According to the changelog the use of mergeVertices was added in version 0.6.6. However it does import from three/examples/jsm instead of three-stdlib. These examples are designed to copy and paste into projects and cause issues when importing, especially when using Next.js.

I was unable to use this in nextjs until I made the import change, hence the PR.

Thanks!