### PR TITLE
fix: prefer bare imports to three

### DIFF
--- a/.changeset/polite-swans-warn.md
+++ b/.changeset/polite-swans-warn.md
@@ -1,0 +1,5 @@
+---
+"@react-three/rapier": patch
+---
+
+fix: prefer bare imports to three

--- a/packages/react-three-rapier/src/Physics.tsx
+++ b/packages/react-three-rapier/src/Physics.tsx
@@ -19,14 +19,13 @@ import {
   RigidBodyHandle,
   World,
 } from "@dimforge/rapier3d-compat";
-import { InstancedMesh, Matrix, Matrix4, Mesh, Object3D, Quaternion, Vector3 } from "three";
+import { InstancedMesh, Matrix, Matrix4, Mesh, Object3D, Quaternion, Vector3, clamp } from "three";
 import {
   rapierQuaternionToQuaternion,
   vectorArrayToVector3,
 } from "./utils";
 import { createWorldApi } from "./api";
 import { _matrix4, _object3d, _position, _quaternion, _rotation, _scale, _vector3 } from "./shared-objects";
-import { clamp } from "three/src/math/MathUtils";
 
 export interface RigidBodyState {
   rigidBody: RigidBody;

--- a/packages/react-three-rapier/src/Physics.tsx
+++ b/packages/react-three-rapier/src/Physics.tsx
@@ -19,7 +19,8 @@ import {
   RigidBodyHandle,
   World,
 } from "@dimforge/rapier3d-compat";
-import { InstancedMesh, Matrix, Matrix4, Mesh, Object3D, Quaternion, Vector3, clamp } from "three";
+import { InstancedMesh, Matrix, Matrix4, Mesh, Object3D, Quaternion, Vector3, MathUtils  } from "three";
+
 import {
   rapierQuaternionToQuaternion,
   vectorArrayToVector3,
@@ -200,7 +201,7 @@ export const Physics: FC<RapierWorldProps> = ({
      * @see https://gafferongames.com/post/fix_your_timestep/
     */
 
-    const clampedDelta = clamp(dt, 0, 0.2)
+    const clampedDelta = MathUtils.clamp(dt, 0, 0.2)
 
     if (timeStepVariable) {
       world.timestep = clampedDelta


### PR DESCRIPTION
Fixes #117 where a core module was imported from a subpath, breaking in an ESM context (servers usually prefer CJS). Curiously, src is defined in three's exports, but you'll want to explicitly specify a file extension when importing from wildcard subpaths (e.g. examples, https://github.com/mrdoob/three.js/issues/24593). Here, this was clearly IDE intellisense being too helpful.