### PR TITLE
feat: add includeInvisible flag

### DIFF
--- a/demo/src/all-colliders/AllCollidersExample.tsx
+++ b/demo/src/all-colliders/AllCollidersExample.tsx
@@ -1,5 +1,5 @@
 import { Box, Cone, Cylinder, Html, Sphere } from "@react-three/drei";
-import { MeshProps } from "@react-three/fiber";
+import { MeshProps, Object3DProps } from "@react-three/fiber";
 import {
   BallCollider,
   CapsuleCollider,
@@ -32,10 +32,10 @@ const RigidBodyBox = (props: RigidBodyProps) => {
   );
 };
 
-const Suzanne = () => {
+const Suzanne = (props?: Object3DProps) => {
   const { nodes: suzanne } = useSuzanne();
   return (
-    <primitive object={suzanne.Suzanne.clone()} castShadow receiveShadow />
+    <primitive object={suzanne.Suzanne.clone()} castShadow receiveShadow {...props} />
   );
 };
 
@@ -124,6 +124,13 @@ export const AllCollidersExample = () => {
         <Suzanne />
 
         <Html>HullCollider</Html>
+      </RigidBody>
+
+      <RigidBody position={[-5, 0, 0]} colliders="hull" includeInvisible>
+        <object3D>
+          <Suzanne visible={false} />
+        </object3D>
+        <Html>Invisible collider</Html>
       </RigidBody>
 
       <RigidBody colliders={false}>

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "demo": "cd demo && yarn dev",
     "release": "yarn build && changeset publish",
     "test": "vitest run",
-    "test:ui": "vitest --ui"
+    "test:ui": "vitest --ui",
+    "ts": "cd packages/react-three-rapier && yarn ts"
   },
   "simple-git-hooks": {
     "commit-msg": "npx --no -- commitlint --edit ${1}",

--- a/packages/react-three-rapier/package.json
+++ b/packages/react-three-rapier/package.json
@@ -8,6 +8,9 @@
   "files": [
     "dist"
   ],
+  "scripts": {
+    "ts": "tsc -w"
+  },
   "devDependencies": {
     "@react-three/drei": "^9.34.1",
     "@react-three/fiber": "^8.8.9",

--- a/packages/react-three-rapier/readme.md
+++ b/packages/react-three-rapier/readme.md
@@ -122,6 +122,16 @@ const Scene = () => (
 );
 ```
 
+If part of our meshes are invisible and you want to include them in the collider creation, use the `includeInvisible` flag.
+
+```tsx
+<RigidBody colliders="hull" includeInvisible>
+  <object3D>
+    <Suzanne visible={false} />
+  </object3D>
+</RigidBody>
+```
+
 ## Instanced Meshes
 
 Instanced meshes can also be used and have automatic colliders generated from their mesh.

--- a/packages/react-three-rapier/src/types.ts
+++ b/packages/react-three-rapier/src/types.ts
@@ -383,6 +383,11 @@ export interface UseRigidBodyOptions extends ColliderProps {
    * Passed down to the object3d representing this collider.
    */
   userData?: Object3DProps["userData"];
+
+  /**
+   * Include invisible objects on the collider creation estimation.
+   */
+  includeInvisible?: boolean;
 }
 
 // Joints

--- a/packages/react-three-rapier/src/utils-collider.ts
+++ b/packages/react-three-rapier/src/utils-collider.ts
@@ -259,7 +259,7 @@ export const createColliderPropsFromChildren: CreateColliderPropsFromChildren =
     object.updateWorldMatrix(true, false);
     const invertedParentMatrixWorld = object.matrixWorld.clone().invert();
 
-    object.traverseVisible((child) => {
+    function traverse(child: Object3D) {
       if ("isMesh" in child) {
         if (ignoreMeshColliders && isChildOfMeshCollider(child as Mesh)) return;
 
@@ -295,7 +295,50 @@ export const createColliderPropsFromChildren: CreateColliderPropsFromChildren =
           scale: [worldScale.x, worldScale.y, worldScale.z]
         });
       }
-    });
+    }
+
+    if(options.includeInvisible) object.traverse(traverse);
+    else object.traverseVisible(traverse);
+
+    // traverse((child) => {
+    // object.traverse((child) => {
+    // // object.traverseVisible((child) => {
+    //   if ("isMesh" in child) {
+    //     if (ignoreMeshColliders && isChildOfMeshCollider(child as Mesh)) return;
+
+    //     const worldScale = child.getWorldScale(_scale);
+    //     const shape = autoColliderMap[
+    //       options.colliders || "cuboid"
+    //     ] as ColliderShape;
+
+    //     child.updateWorldMatrix(true, false);
+    //     _matrix4
+    //       .copy(child.matrixWorld)
+    //       .premultiply(invertedParentMatrixWorld)
+    //       .decompose(_position, _rotation, _scale);
+
+    //     const rotationEuler = new Euler().setFromQuaternion(_rotation, "XYZ");
+
+    //     const { geometry } = child as Mesh;
+    //     const { args, offset } = getColliderArgsFromGeometry(
+    //       geometry,
+    //       options.colliders || "cuboid"
+    //     );
+
+    //     colliderProps.push({
+    //       ...options,
+    //       args: args,
+    //       shape: shape,
+    //       rotation: [rotationEuler.x, rotationEuler.y, rotationEuler.z],
+    //       position: [
+    //         _position.x + offset.x * worldScale.x,
+    //         _position.y + offset.y * worldScale.y,
+    //         _position.z + offset.z * worldScale.z
+    //       ],
+    //       scale: [worldScale.x, worldScale.y, worldScale.z]
+    //     });
+    //   }
+    // });
 
     return colliderProps;
   };


### PR DESCRIPTION
Add an `includeInvisible` flag to `<RigidBody>`, so that it can generate a collider from invisible meshes.