### PR TITLE
Add support for declaratively setting RigidBody userData

### DIFF
--- a/.changeset/quiet-lizards-end.md
+++ b/.changeset/quiet-lizards-end.md
@@ -1,0 +1,5 @@
+---
+"@react-three/rapier": patch
+---
+
+The RigidBody `userData` prop now sets rigid body `userData`, as well as the object3d `userData`

--- a/.changeset/quiet-lizards-end.md
+++ b/.changeset/quiet-lizards-end.md
@@ -2,4 +2,4 @@
 "@react-three/rapier": patch
 ---
 
-The RigidBody `userData` prop now sets rigid body `userData`, as well as the object3d `userData`
+The RigidBody `userData` prop now sets rigid body `userData`, as well as the object3d `userData` (@isaac-mason)

--- a/packages/react-three-rapier/src/hooks.ts
+++ b/packages/react-three-rapier/src/hooks.ts
@@ -117,9 +117,6 @@ export const useRigidBody = <O extends Object3D>(
       ref.current = new Object3D() as O;
     }
 
-    // isSleeping used for onSleep and onWake events
-    ref.current.userData.isSleeping = false;
-
     rigidBodyStates.set(
       rigidBody.handle,
       createRigidBodyState({

--- a/packages/react-three-rapier/src/utils-rigidbody.ts
+++ b/packages/react-three-rapier/src/utils-rigidbody.ts
@@ -92,6 +92,9 @@ const mutableRigidBodyOptions: MutableRigidBodyOptions = {
   ccd: (rb: RigidBody, value: boolean) => {
     rb.enableCcd(value);
   },
+  userData: (rb: RigidBody, value: { [key: string]: any }) => {
+    rb.userData = value;
+  },
   position: () => {},
   rotation: () => {},
   quaternion: () => {},


### PR DESCRIPTION
- The `RigidBody` `userData` prop now sets rigid body `userData`, as well as the object3d `userData` 
- Removed `isSleeping` `userData`, as it is unused
- Addresses https://github.com/pmndrs/react-three-rapier/issues/143