### PR TITLE
Add a name prop to the RigidBody and Collider components

### DIFF
--- a/.changeset/slow-dryers-whisper.md
+++ b/.changeset/slow-dryers-whisper.md
@@ -2,4 +2,4 @@
 "@react-three/rapier": minor
 ---
 
-Add name prop to RigidBody and collider components
+Add name prop to RigidBody and collider components (@micmania1)

--- a/.changeset/slow-dryers-whisper.md
+++ b/.changeset/slow-dryers-whisper.md
@@ -1,0 +1,5 @@
+---
+"@react-three/rapier": minor
+---
+
+Add name prop to RigidBody and collider components

--- a/packages/react-three-rapier/src/AnyCollider.tsx
+++ b/packages/react-three-rapier/src/AnyCollider.tsx
@@ -41,7 +41,7 @@ export interface ColliderProps extends UseColliderOptions<any> {
 export const AnyCollider = memo(
   React.forwardRef(
     (props: ColliderProps, forwardedRef: ForwardedRef<Collider[]>) => {
-      const { children, position, rotation, quaternion, scale } = props;
+      const { children, position, rotation, quaternion, scale, name } = props;
       const { world, colliderEvents, colliderStates } = useRapier();
       const rigidBodyContext = useRigidBodyContext();
       const ref = useRef<Object3D>(null);
@@ -131,6 +131,7 @@ export const AnyCollider = memo(
           quaternion={quaternion}
           scale={scale}
           ref={ref}
+          name={name}
         >
           {children}
         </object3D>

--- a/packages/react-three-rapier/src/types.ts
+++ b/packages/react-three-rapier/src/types.ts
@@ -117,6 +117,11 @@ export type Boolean3Array = [x: boolean, y: boolean, z: boolean];
 
 export interface UseColliderOptions<ColliderArgs extends Array<unknown>> {
   /**
+   * The optional name passed to THREE's Object3D
+   */
+  name?: string,
+
+  /**
    * The shape of your collider
    */
   shape?: ColliderShape;


### PR DESCRIPTION
## Use case

When two objects collide, I want to play a different sound depending on which two objects are colliding.

## Solution

I've added the name to RidigBody and Collider components so that it can be passed through to Object3D. When events are fired (collision and contact forces) then I can check the name of the colliding object to determined whether to perform other actions.

I don't _believe_ collision/solver groups would work here since it would stop the event from being fired.


## Example
note: example includes `onContactForce` event which comes from #142 

```tsx
<Ball
  mass={ballMass}
  onContactForce={({ totalForceMagnitude }) => {
    const maxBallForce = ballMass * 1000;
    const volume = totalForceMagnitude > maxBallForce ? 1 : totalForceMagnitude / maxBallForce;

    const hasHitGlass = [payload.rigidBodyObject?.name, payload.colliderObject?.name].includes('glass');
    if (hasHitGlass && ballVsGlassAudioRef.current && !ballVsGlassAudioRef.current.isPlaying) {
      ballVsGlassAudioRef.current.setVolume(volume);
      ballVsGlassAudioRef.current.play();
    } else if (ballVsPlasticAudioRef.current && !ballVsPlasticAudioRef.current.isPlaying) {
      ballVsPlasticAudioRef.current.setVolume(volume);
      ballVsPlasticAudioRef.current.play();
    }
  }}
>
  <PositionalAudio url="/assets/audio/sfx/foam_vs_window.mp3" distance={2} loop={false} ref={ballVsGlassAudioRef} />
  <PositionalAudio url="/assets/audio/sfx/foam_vs_table.mp3" distance={2} loop={false} ref={ballVsPlasticAudioRef} />
</Ball>
```