### PR TITLE
feat: add support for revolute and prismatic joint limits

### DIFF
--- a/.changeset/orange-books-boil.md
+++ b/.changeset/orange-books-boil.md
@@ -1,0 +1,5 @@
+---
+"@react-three/rapier": patch
+---
+
+feat: add support for revolute and prismatic joint limits (@planktonrobo)

--- a/packages/react-three-rapier/src/hooks.ts
+++ b/packages/react-three-rapier/src/hooks.ts
@@ -249,10 +249,10 @@ export const useRevoluteJoint: UseImpulseJoint<RevoluteJointParams> = (
       vectorArrayToVector3(body2Anchor),
       vectorArrayToVector3(axis)
     )
-    if (limits){
-      params.limitsEnabled = true
-      params.limits = limits
-    }
+  if (limits){
+    params.limitsEnabled = true
+    params.limits = limits
+  }
   return useImpulseJoint<RevoluteImpulseJoint>(
     body1,
     body2,
@@ -276,10 +276,10 @@ export const usePrismaticJoint: UseImpulseJoint<PrismaticJointParams> = (
       vectorArrayToVector3(body2Anchor),
       vectorArrayToVector3(axis)
     )
-     if (limits){
-      params.limitsEnabled = true
-      params.limits = limits
-    }
+  if (limits){
+    params.limitsEnabled = true
+    params.limits = limits
+  }
   return useImpulseJoint<PrismaticImpulseJoint>(
     body1,
     body2,

--- a/packages/react-three-rapier/src/hooks.ts
+++ b/packages/react-three-rapier/src/hooks.ts
@@ -240,18 +240,23 @@ export const useSphericalJoint: UseImpulseJoint<SphericalJointParams> = (
 export const useRevoluteJoint: UseImpulseJoint<RevoluteJointParams> = (
   body1,
   body2,
-  [body1Anchor, body2Anchor, axis]
+  [body1Anchor, body2Anchor, axis, limits]
 ) => {
   const { rapier } = useRapier();
 
-  return useImpulseJoint<RevoluteImpulseJoint>(
-    body1,
-    body2,
-    rapier.JointData.revolute(
+  const params = rapier.JointData.revolute(
       vectorArrayToVector3(body1Anchor),
       vectorArrayToVector3(body2Anchor),
       vectorArrayToVector3(axis)
     )
+    if (limits){
+      params.limitsEnabled = true
+      params.limits = limits
+    }
+  return useImpulseJoint<RevoluteImpulseJoint>(
+    body1,
+    body2,
+    params
   );
 };
 
@@ -263,17 +268,21 @@ export const useRevoluteJoint: UseImpulseJoint<RevoluteJointParams> = (
 export const usePrismaticJoint: UseImpulseJoint<PrismaticJointParams> = (
   body1,
   body2,
-  [body1Anchor, body2Anchor, axis]
+  [body1Anchor, body2Anchor, axis, limits],
 ) => {
   const { rapier } = useRapier();
-
-  return useImpulseJoint<PrismaticImpulseJoint>(
-    body1,
-    body2,
-    rapier.JointData.prismatic(
+  const params = rapier.JointData.prismatic(
       vectorArrayToVector3(body1Anchor),
       vectorArrayToVector3(body2Anchor),
       vectorArrayToVector3(axis)
     )
+     if (limits){
+      params.limitsEnabled = true
+      params.limits = limits
+    }
+  return useImpulseJoint<PrismaticImpulseJoint>(
+    body1,
+    body2,
+    params
   );
 };

--- a/packages/react-three-rapier/src/types.ts
+++ b/packages/react-three-rapier/src/types.ts
@@ -440,13 +440,15 @@ export type PrismaticJointParams = [
   body1Anchor: Vector3Array,
   body1LocalFrame: Vector3Array,
   body2Anchor: Vector3Array,
-  body2LocalFrame: Vector3Array
+  body2LocalFrame: Vector3Array,
+  limits?: [min: number, max: number] 
 ];
 
 export type RevoluteJointParams = [
   body1Anchor: Vector3Array,
   body2Anchor: Vector3Array,
-  axis: Vector3Array
+  axis: Vector3Array,
+  limits?: [min: number, max: number] 
 ];
 
 export type RigidBodyApiRef = MutableRefObject<undefined | null | RigidBodyApi>;


### PR DESCRIPTION
adds support for revolute and prismatic joint limits.

can now pass in optional min and max joint limits tuple to `useRevoluteJoint(parentRef, childRef, params)` and `useRevoluteJoint(parentRef, childRef, params)`

where params =  `
                [parentAnchor.x, parentAnchor.y, parentAnchor.z],
                [childAnchor.x,, childAnchor.x, childAnchor.x],
                [axis.x, axis.y, axis.z],
                [minJointLimit, maxJointLimit]
`