### PR TITLE
fix(RigidBody): canSleep always true due to using logical OR instead of nullish coalescing operator

### DIFF
--- a/.changeset/lovely-rockets-unite.md
+++ b/.changeset/lovely-rockets-unite.md
@@ -1,0 +1,5 @@
+---
+"@react-three/rapier": patch
+---
+
+fix(RigidBody): canSleep always true due to using logical OR instead of nullish coalescing operator

--- a/packages/react-three-rapier/src/utils-rigidbody.ts
+++ b/packages/react-three-rapier/src/utils-rigidbody.ts
@@ -18,7 +18,7 @@ export const rigidBodyDescFromOptions = (options: RigidBodyProps) => {
   const desc = new RigidBodyDesc(type);
 
   // Apply immutable options
-  desc.canSleep = options?.canSleep || true;
+  desc.canSleep = options?.canSleep ?? true;
 
   return desc;
 };


### PR DESCRIPTION
- fix(RigidBody): canSleep always true due to using logical OR instead of nullish coalescing operator
  - If `options.canSleep` is `false`, the logical OR will default to `true` as `false` is falsy
  - We want to use the nullish coalescing operator so we're only defaulting to `true` if the given value is `null` or `undefined`