### PR TITLE
fix: attractors with timeStep='vary', interpolation previousState only storing last body

### DIFF
--- a/.changeset/eighty-swans-jog.md
+++ b/.changeset/eighty-swans-jog.md
@@ -2,4 +2,4 @@
 "@react-three/rapier": patch
 ---
 
-fix: attractors broken when using timeStep="vary"
+fix: attractors broken when using timeStep="vary" (@isaac-mason)

--- a/.changeset/eighty-swans-jog.md
+++ b/.changeset/eighty-swans-jog.md
@@ -1,0 +1,5 @@
+---
+"@react-three/rapier": patch
+---
+
+fix: attractors broken when using timeStep="vary"

--- a/.changeset/poor-apes-pay.md
+++ b/.changeset/poor-apes-pay.md
@@ -1,0 +1,5 @@
+---
+"@react-three/rapier": patch
+---
+
+fix: previous rigid body positions used for interpolation weren't being populated correctly

--- a/packages/react-three-rapier/src/Physics.tsx
+++ b/packages/react-three-rapier/src/Physics.tsx
@@ -384,6 +384,13 @@ export const Physics: FC<PhysicsProps> = ({
       const clampedDelta = MathUtils.clamp(dt, 0, 0.2);
 
       const stepWorld = () => {
+        // Apply attractors
+        world.forEachRigidBody((body) => {
+          attractorStates.forEach((attractorState) => {
+            applyAttractorForceOnRigidBody(body, attractorState);
+          });
+        });
+
         // Trigger beforeStep callbacks
         beforeStepCallbacks.forEach((callback) => {
           callback(api);
@@ -409,22 +416,17 @@ export const Physics: FC<PhysicsProps> = ({
         steppingState.accumulator += clampedDelta;
 
         while (steppingState.accumulator >= timeStep) {
-          world.forEachRigidBody((body) => {
-            // Set up previous state
-            // needed for accurate interpolations if the world steps more than once
-            if (interpolate) {
-              steppingState.previousState = {};
+          // Set up previous state
+          // needed for accurate interpolations if the world steps more than once
+          if (interpolate) {
+            steppingState.previousState = {};
+            world.forEachRigidBody((body) => {
               steppingState.previousState[body.handle] = {
                 position: body.translation(),
                 rotation: body.rotation()
               };
-            }
-
-            // Apply attractors
-            attractorStates.forEach((attractorState) => {
-              applyAttractorForceOnRigidBody(body, attractorState);
             });
-          });
+          }
 
           stepWorld();
 


### PR DESCRIPTION
## Fixes
- Attractors broken when using timeStep="vary"
- Previous rigid body positions used for interpolation weren't being populated correctly