### PR TITLE
feat: change callbacks for `useBeforePhysicsStep` and `useAfterPhysicsStep` to be mutable

### DIFF
--- a/.changeset/few-fishes-bow.md
+++ b/.changeset/few-fishes-bow.md
@@ -2,4 +2,4 @@
 "@react-three/rapier": patch
 ---
 
-feat: change callbacks for `useBeforePhysicsStep` and `useAfterPhysicsStep` to be mutable
+feat: change callbacks for `useBeforePhysicsStep` and `useAfterPhysicsStep` to be mutable (@isaac-mason)

--- a/.changeset/few-fishes-bow.md
+++ b/.changeset/few-fishes-bow.md
@@ -1,0 +1,5 @@
+---
+"@react-three/rapier": patch
+---
+
+feat: change callbacks for `useBeforePhysicsStep` and `useAfterPhysicsStep` to be mutable

--- a/packages/react-three-rapier/src/components/Physics.tsx
+++ b/packages/react-three-rapier/src/components/Physics.tsx
@@ -67,7 +67,7 @@ export type RigidBodyStateMap = Map<RigidBody["handle"], RigidBodyState>;
 
 export type WorldStepCallback = (worldApi: WorldApi) => void;
 
-export type WorldStepCallbackSet = Set<WorldStepCallback>;
+export type WorldStepCallbackSet = Set<{ current: WorldStepCallback }>;
 
 export interface ColliderState {
   collider: Collider;
@@ -396,14 +396,14 @@ export const Physics: FC<PhysicsProps> = ({
 
         // Trigger beforeStep callbacks
         beforeStepCallbacks.forEach((callback) => {
-          callback(api);
+          callback.current(api);
         });
 
         world.step(eventQueue);
 
         // Trigger afterStep callbacks
         afterStepCallbacks.forEach((callback) => {
-          callback(api);
+          callback.current(api);
         });
       };
 

--- a/packages/react-three-rapier/src/hooks/hooks.ts
+++ b/packages/react-three-rapier/src/hooks/hooks.ts
@@ -2,6 +2,7 @@ import React, {
   MutableRefObject,
   useContext,
   useEffect,
+  useRef,
   useState
 } from "react";
 import {
@@ -13,6 +14,15 @@ import { Object3D } from "three";
 
 import { ColliderProps, RigidBodyProps } from "..";
 import { createColliderPropsFromChildren } from "../utils/utils-collider";
+
+// Utils
+const useMutableCallback = <T>(fn: T) => {
+  const ref = useRef<T>(fn);
+  useEffect(() => {
+    ref.current = fn;
+  }, [fn]);
+  return ref;
+};
 
 // External hooks
 /**
@@ -30,11 +40,13 @@ export const useRapier = () => {
 export const useBeforePhysicsStep = (callback: WorldStepCallback) => {
   const { beforeStepCallbacks } = useRapier();
 
+  const ref = useMutableCallback(callback);
+
   useEffect(() => {
-    beforeStepCallbacks.add(callback);
+    beforeStepCallbacks.add(ref);
 
     return () => {
-      beforeStepCallbacks.delete(callback);
+      beforeStepCallbacks.delete(ref);
     };
   }, []);
 };
@@ -46,11 +58,13 @@ export const useBeforePhysicsStep = (callback: WorldStepCallback) => {
 export const useAfterPhysicsStep = (callback: WorldStepCallback) => {
   const { afterStepCallbacks } = useRapier();
 
+  const ref = useMutableCallback(callback);
+
   useEffect(() => {
-    afterStepCallbacks.add(callback);
+    afterStepCallbacks.add(ref);
 
     return () => {
-      afterStepCallbacks.delete(callback);
+      afterStepCallbacks.delete(ref);
     };
   }, []);
 };


### PR DESCRIPTION
- feat: change callbacks for `useBeforePhysicsStep` and `useAfterPhysicsStep` to be mutable
  - borrowed approach from `@react-three/fiber` `useFrame` - https://github.com/pmndrs/react-three-fiber/blob/master/packages/fiber/src/core/hooks.tsx#L64
  - without this, updated callbacks with state changes won't be called
- An alternative approach could be providing a dependencies array 