### PR TITLE
Feat/on demand rendering

### DIFF
--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -134,7 +134,7 @@ export const App = () => {
       }}
     >
       <Suspense fallback="Loading...">
-        <Canvas shadows>
+        <Canvas shadows frameloop="demand">
           <StrictMode>
             <Physics paused={paused} key={physicsKey}>
               <directionalLight

--- a/packages/react-three-rapier/readme.md
+++ b/packages/react-three-rapier/readme.md
@@ -131,7 +131,7 @@ Supported values:
 
 - `"cuboid"`, creates a CuboidCollider based on the bounding box of the mesh
 - `"ball"`, creates a SphereCollider based on the bounding sphere of the mesh
-- `"trimesh"`, creates a TrimeshCollider based on the mesh's geometry -- note trimeshes are massless by default (https://rapier.rs/docs/user_guides/javascript/common_mistakes#rigid-body-isnt-affected-by-gravity)
+- `"trimesh"`, creates a TrimeshCollider based on the mesh's geometry
 - `"hull"`, creates a ConvexHullCollider based on the mesh's geometry
 - `false`, disables auto-generation
 

--- a/packages/react-three-rapier/src/components/Physics.tsx
+++ b/packages/react-three-rapier/src/components/Physics.tsx
@@ -7,7 +7,7 @@ import {
   RigidBodyHandle,
   World
 } from "@dimforge/rapier3d-compat";
-import { useFrame } from "@react-three/fiber";
+import { useThree } from "@react-three/fiber";
 import React, {
   createContext,
   FC,
@@ -43,6 +43,7 @@ import {
   useConst,
   vectorArrayToVector3
 } from "../utils/utils";
+import { useRaf } from "../utils/utils-physics";
 import {
   applyAttractorForceOnRigidBody,
   AttractorState,
@@ -283,6 +284,7 @@ export const Physics: FC<PhysicsProps> = ({
   interpolate = true
 }) => {
   const rapier = useAsset(importRapier);
+  const { invalidate } = useThree();
 
   const worldRef = useRef<World>();
   const getWorldRef = useRef(() => {
@@ -635,13 +637,17 @@ export const Physics: FC<PhysicsProps> = ({
           maxForceMagnitude: event.maxForceMagnitude()
         });
       });
+
+      world.forEachActiveRigidBody((body) => {
+        invalidate();
+      });
     },
     [paused, timeStep, interpolate]
   );
 
-  useFrame((_, dt) => {
+  useRaf((dt) => {
     if (!paused) step(dt);
-  }, updatePriority);
+  });
 
   const context = useMemo<RapierContext>(
     () => ({

--- a/packages/react-three-rapier/src/components/Physics.tsx
+++ b/packages/react-three-rapier/src/components/Physics.tsx
@@ -254,14 +254,6 @@ export interface PhysicsProps {
   paused?: boolean;
 
   /**
-   * The update priority at which the physics simulation should run.
-   *
-   * @see {@link https://docs.pmnd.rs/react-three-fiber/api/hooks#taking-over-the-render-loop}
-   * @defaultValue undefined
-   */
-  updatePriority?: number;
-
-  /**
    * Interpolate the world transform using the frame delta times.
    * Has no effect if timeStep is set to "vary".
    *
@@ -280,7 +272,6 @@ export const Physics: FC<PhysicsProps> = ({
   children,
   timeStep = 1 / 60,
   paused = false,
-  updatePriority,
   interpolate = true
 }) => {
   const rapier = useAsset(importRapier);

--- a/packages/react-three-rapier/src/utils/utils-physics.ts
+++ b/packages/react-three-rapier/src/utils/utils-physics.ts
@@ -1,0 +1,26 @@
+import { useEffect, useRef } from "react";
+
+export const useRaf = (callback: (dt: number) => void) => {
+  const cb = useRef(callback);
+  const raf = useRef(0);
+  const lastFrame = useRef(0);
+
+  useEffect(() => {
+    cb.current = callback;
+  }, [callback]);
+
+  useEffect(() => {
+    const loop = () => {
+      const now = performance.now();
+      const delta = now - lastFrame.current;
+
+      raf.current = requestAnimationFrame(loop);
+      cb.current(delta / 1000);
+      lastFrame.current = now;
+    };
+
+    raf.current = requestAnimationFrame(loop);
+
+    return () => cancelAnimationFrame(raf.current);
+  }, []);
+};


### PR DESCRIPTION
This adds the ability to utilize the on-demand rendering strategy from `@react-three/fiber`. It also removes the ability to control the `updatePriority` of the frameloop.