### PR TITLE
Update readme.md

### DIFF
--- a/packages/react-three-rapier/readme.md
+++ b/packages/react-three-rapier/readme.md
@@ -27,7 +27,7 @@ The goal of this library to is to provide a fast physics engine with minimal fri
 ```tsx
 import { Box, Torus } from "@react-three/drei";
 import { Canvas } from "@react-three/fiber";
-import { Physics, RigidBody, Debug, CuboidCollider } from "@react-three/rapier";
+import { Physics, RigidBody, CuboidCollider } from "@react-three/rapier";
 
 const App = () => {
   return (


### PR DESCRIPTION
Debug is no longer exported from the main repo. so a bit confusing and misleading for new comers

* Remove Debug from rapier import, Debug is deprecated.
* debug prop on physics is the new approach