### PR TITLE
refactor(useRapier): throw when used outside Physics

### DIFF
--- a/.changeset/silent-chefs-refuse.md
+++ b/.changeset/silent-chefs-refuse.md
@@ -1,0 +1,5 @@
+---
+"@react-three/rapier": patch
+---
+
+Throw useful error when `usePhysics` used outside `<Physics />` (@CodyJasonBennett)

--- a/packages/react-three-rapier/src/hooks/hooks.ts
+++ b/packages/react-three-rapier/src/hooks/hooks.ts
@@ -29,8 +29,10 @@ const useMutableCallback = <T>(fn: T) => {
  * Exposes the Rapier context, and world
  * @category Hooks
  */
-export const useRapier = () => {
-  return useContext(rapierContext) as RapierContext;
+export const useRapier = (): RapierContext => {
+  const rapier = useContext(rapierContext);
+  if (!rapier) throw new Error('react-three-rapier: useRapier must be used within <Physics />!')
+  return rapier;
 };
 
 /**


### PR DESCRIPTION
Throws a helpful error when hooks or components are used outside of a `Physics` provider.