### PR TITLE
[fix] updated incorrect function call in documentation 

### DIFF
--- a/packages/react-three-rapier/readme.md
+++ b/packages/react-three-rapier/readme.md
@@ -413,7 +413,7 @@ const Scene = () => {
       // While Rapier's return types need conversion, setting values can be done directly with Three.js types
       rigidBody.current.setTranslation(position, true);
       rigidBody.current.setRotation(quaternion, true);
-      rigidBody.current.setAngVel({ x: 0, y: 2, z: 0 }, true);
+      rigidBody.current.setAngvel({ x: 0, y: 2, z: 0 }, true);
     }
   }, []);
 


### PR DESCRIPTION
Under [Moving things around, and applying forces](https://github.com/pmndrs/react-three-rapier#moving-things-around-and-applying-forces) updated incorrect function call setAngVel to setAngvel.