### PR TITLE
one-way-platform issue

### DIFF
--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -38,7 +38,8 @@ import { PerformanceExample } from "./examples/performance/PeformanceExample";
 import { DynamicTypeChangeExample } from "./examples/dynamic-type-change/DynamicTypeChangeExample";
 import { StutteringExample } from "./examples/stuttering/StutteringExample";
 import { ImmutablePropsExample } from "./examples/immutable-props/ImmutablePropsExample";
-import { SnapshotExample } from './examples/snapshot/SnapshotExample';
+import { SnapshotExample } from "./examples/snapshot/SnapshotExample";
+import { OneWayPlatform } from "./examples/one-way-platform/OneWayPlatform";
 
 const demoContext = createContext<{
   setDebug?(f: boolean): void;
@@ -90,7 +91,7 @@ const Floor = () => {
 };
 
 const routes: Record<string, ReactNode> = {
-  "": <Shapes />,
+  "": <OneWayPlatform />,
   joints: <Joints />,
   components: <ComponentsExample />,
   cradle: <CradleExample />,
@@ -200,7 +201,7 @@ export const App = () => {
       >
         {Object.keys(routes).map((key) => (
           <Link key={key} to={key} end>
-            {key.replace(/-/g, " ") || "Plinko"}
+            {key.replace(/-/g, " ") || "One Way Platform"}
           </Link>
         ))}
 

--- a/demo/src/examples/one-way-platform/OneWayPlatform.tsx
+++ b/demo/src/examples/one-way-platform/OneWayPlatform.tsx
@@ -1,0 +1,101 @@
+import { Sphere } from "@react-three/drei";
+import { useThree } from "@react-three/fiber";
+import {
+  CuboidCollider,
+  RapierCollider,
+  RapierRigidBody,
+  RigidBody,
+  useRapier
+} from "@react-three/rapier";
+import { useCallback, useEffect, useRef } from "react";
+import { Vector3 } from "three";
+import { Demo } from "../../App";
+
+export const OneWayPlatform: Demo = () => {
+  const ref = useRef<RapierRigidBody>(null);
+  const collider = useRef<RapierCollider>(null);
+
+  const ball = useRef<RapierRigidBody>(null);
+  const { camera } = useThree();
+
+  useEffect(() => {
+    camera.position.set(0, 10, 20);
+    camera.lookAt(0, 0, 0);
+    camera.updateProjectionMatrix();
+
+    window.addEventListener("click", () => {
+      ball.current?.applyImpulse(new Vector3(0, 50, 0), true);
+    });
+  }, []);
+
+  const { filterContactPairHooks, world } = useRapier();
+
+  const hook = useCallback(
+    (c1: number, c2: number, b1: number, b2: number) => {
+      try {
+        const collider1 = world.getCollider(c1);
+        const collider2 = world.getCollider(c2);
+
+        const body1 = world.getRigidBody(b1);
+        const body2 = world.getRigidBody(b2);
+
+        if (
+          (body1.userData as any)?.type &&
+          (body1.userData as any).type === "platform" &&
+          (body2.userData as any)?.type &&
+          (body2.userData as any)?.type === "ball"
+        ) {
+          // Once we get try to get access to the ball and platform, the "hook" that we pass to filterContactPairHooks crashes
+
+          // why does this crash here? what's wrong with the below setup?
+          const platformPosition = body1.translation();
+          const ballVelocity = body2.linvel();
+          const ballPosition = body2.translation();
+
+          // also doesn't work
+          // const platformPosition = ref.current!.translation();
+          // const ballVelocity = ball.current!.linvel();
+          // const ballPosition = ref.current!.translation();
+
+          // Allow collision if the ball is moving downwards and above the platform
+          if (ballVelocity.y < 0 && ballPosition.y > platformPosition.y) {
+            return 1; // Process the collision
+          }
+        }
+
+        return 0; // Ignore the collision
+      } catch (error) {
+        console.log(error);
+        return null;
+      }
+    },
+    [world]
+  );
+
+  useEffect(() => {
+    collider.current?.setActiveHooks(1);
+    filterContactPairHooks.push(hook);
+  }, []);
+
+  return (
+    <group>
+      <RigidBody
+        ref={ball}
+        colliders="ball"
+        position={[0, -5, 0]}
+        userData={{ type: "ball" }}
+      >
+        <Sphere castShadow receiveShadow>
+          <meshPhysicalMaterial color="red" />
+        </Sphere>
+      </RigidBody>
+      <mesh>
+        <boxGeometry args={[10, 0.1, 10]} />
+        <meshStandardMaterial color={"grey"} opacity={0.5} transparent={true} />
+      </mesh>
+      <RigidBody type="fixed" userData={{ type: "platform" }} ref={ref}>
+        <CuboidCollider args={[10, 0.1, 10]} ref={collider} />
+      </RigidBody>
+    </group>
+  );
+};


### PR DESCRIPTION
## Description
PR for https://github.com/pmndrs/react-three-rapier/issues/597

We can get one-way-platforms to work by [passing an additional hooks param](https://github.com/pmndrs/react-three-rapier/compare/main...driescroons:react-three-rapier:main#diff-4b2d5bdbbfe04ccbc1bce88bef0cf1211fe756872a2e249cc6f4a0d5fef27ac2R550) to world.step(eventQueue, hooks) of type PhysicsHooks.

In order for us to get access to this in components, [I added filterContactPairHooks and filterIntersectionPairHooks](https://github.com/pmndrs/react-three-rapier/compare/main...driescroons:react-three-rapier:main#diff-4b2d5bdbbfe04ccbc1bce88bef0cf1211fe756872a2e249cc6f4a0d5fef27ac2R810) to useRapier.

This allows us to register a [hook in our OneWayPlatform.jsx demo](https://github.com/pmndrs/react-three-rapier/compare/main...driescroons:react-three-rapier:main#diff-8beb228ac1de48fc3bc2fd12bc43e4ec1e4af28fbb37f9234f9f425e0d96f0b8R33) that we can push to filterContactPairHooks. We also need to make sure we set setActiveHooks to one for either our ball or platform.

This works, but when I try to get access to body's linvel or translation in the hook, from either the ref, or the params I get the above error. How am I able to access the body in that hook?



### Type of change
<!-- Remove unrelated items -->

- 🐛 Bug fix
- ✨ New feature
- 📦 Other (tests, refactoring, docs, etc.)

### Checklist:
<!-- Check all that apply, remove any that don't -->

- [ ] 🔍 I have performed a self-review of my code
- [ ] 💬 I have commented my code, particularly in hard-to-understand areas
- [ ] 📗 I have made corresponding changes to the documentation
- [ ] ⭐️ My changes generate no new warnings
- [ ] 🧪 I have added tests
- [ ] 🟢 All new and existing unit tests pass