### PR TITLE
fix: move away from use-asset

### DIFF
--- a/.changeset/strong-crabs-mate.md
+++ b/.changeset/strong-crabs-mate.md
@@ -1,0 +1,5 @@
+---
+"@react-three/rapier": patch
+---
+
+fix: move away from use-asset

--- a/packages/react-three-rapier/package.json
+++ b/packages/react-three-rapier/package.json
@@ -30,8 +30,8 @@
   },
   "dependencies": {
     "@dimforge/rapier3d-compat": "0.12.0",
-    "three-stdlib": "2.23.9",
-    "use-asset": "1.0.4"
+    "suspend-react": "^0.1.3",
+    "three-stdlib": "2.23.9"
   },
   "repository": "https://github.com/pmndrs/react-three-rapier/tree/master/packages/react-three-rapier"
 }

--- a/packages/react-three-rapier/src/components/Physics.tsx
+++ b/packages/react-three-rapier/src/components/Physics.tsx
@@ -18,7 +18,7 @@ import React, {
   useState
 } from "react";
 import { MathUtils, Matrix4, Object3D, Quaternion, Vector3 } from "three";
-import { useAsset } from "use-asset";
+import { suspend } from "suspend-react";
 import {
   CollisionPayload,
   CollisionEnterHandler,
@@ -409,7 +409,7 @@ export const Physics: FC<PhysicsProps> = (props) => {
     maxCcdSubsteps = 1,
     erp = 0.8
   } = props;
-  const rapier = useAsset(importRapier);
+  const rapier = suspend(importRapier, ["@react-thee/rapier", importRapier]);
   const { invalidate } = useThree();
 
   const rigidBodyStates = useConst<RigidBodyStateMap>(() => new Map());

--- a/yarn.lock
+++ b/yarn.lock
@@ -4041,7 +4041,7 @@ fast-deep-equal@^2.0.1:
   resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz"
   integrity sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==
 
-fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
+fast-deep-equal@^3.1.1:
   version "3.1.3"
   resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
@@ -7532,13 +7532,6 @@ url-parse-lax@^3.0.0:
   integrity sha512-NjFKA0DidqPa5ciFcSrXnAltTtzz84ogy+NebPvfEgAck0+TNg4UJ4IN+fB7zRZfbgUf0syOo9MDxFkDSMuFaQ==
   dependencies:
     prepend-http "^2.0.0"
-
-use-asset@1.0.4:
-  version "1.0.4"
-  resolved "https://registry.npmjs.org/use-asset/-/use-asset-1.0.4.tgz"
-  integrity sha512-7/hqDrWa0iMnCoET9W1T07EmD4Eg/Wmoj/X8TGBc++ECRK4m5yTsjP4O6s0yagbxfqIOuUkIxe2/sA+VR2GxZA==
-  dependencies:
-    fast-deep-equal "^3.1.3"
 
 util-deprecate@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
use-asset has been replaced by https://github.com/pmndrs/suspend-react this is also what fiber uses internally and for all loader hooks. would save a little bundle size and make it more aligned.