### PR TITLE
chore: exit changesets prerelease mode

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "canary",
   "initialVersions": {
     "demo": "0.0.0",


### PR DESCRIPTION
- exit canary mode for non-canary @react-three/rapier v2.0.0 release