### PR TITLE
fix: debug geometry not updating correctly for WebGPURenderer

### DIFF
--- a/.changeset/hungry-hornets-deliver.md
+++ b/.changeset/hungry-hornets-deliver.md
@@ -1,0 +1,5 @@
+---
+"@react-three/rapier": patch
+---
+
+fix: debug geometry not updating correctly for WebGPURenderer

--- a/packages/react-three-rapier/src/components/Debug.tsx
+++ b/packages/react-three-rapier/src/components/Debug.tsx
@@ -1,22 +1,8 @@
 import React, { memo, useRef } from "react";
 import { useFrame } from "@react-three/fiber";
-import { BufferAttribute, LineSegments } from "three";
+import { BufferAttribute, BufferGeometry, LineSegments } from "three";
 import { useRapier } from "../hooks/hooks";
 import { _vector3 } from "../utils/shared-objects";
-
-function mapsEqual(map1: Map<string, any>, map2: Map<string, any>) {
-  var testVal;
-  if (map1.size !== map2.size) {
-    return false;
-  }
-  for (var [key, val] of map1) {
-    testVal = map2.get(key);
-    if (testVal !== val || (testVal === undefined && !map2.has(key))) {
-      return false;
-    }
-  }
-  return true;
-}
 
 export const Debug = memo(() => {
   const { world } = useRapier();
@@ -28,11 +14,12 @@ export const Debug = memo(() => {
 
     const buffers = world.debugRender();
 
-    mesh.geometry.setAttribute(
-      "position",
-      new BufferAttribute(buffers.vertices, 3)
-    );
-    mesh.geometry.setAttribute("color", new BufferAttribute(buffers.colors, 4));
+    const geometry = new BufferGeometry();
+    geometry.setAttribute("position", new BufferAttribute(buffers.vertices, 3));
+    geometry.setAttribute("color", new BufferAttribute(buffers.colors, 4));
+
+    mesh.geometry.dispose();
+    mesh.geometry = geometry;
   });
 
   return (


### PR DESCRIPTION
## Description
- WebGPURenderer no longer allows calling setAttribute after initial geometry creation.
  - Fix usage with WebGPURenderer by constructing a new BufferGeometry and disposing the previous
- Removed unused mapsEqual function

### Type of change
- 🐛 Bug fix

### Checklist:

- [x] 🔍 I have performed a self-review of my code
- [x] 💬 I have commented my code, particularly in hard-to-understand areas
- [x] 📗 I have made corresponding changes to the documentation
- x] ⭐️ My changes generate no new warnings
- [ ] 🧪 I have added tests
- [x] 🟢 All new and existing unit tests pass